### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/graduation.yml
+++ b/.github/workflows/graduation.yml
@@ -4,6 +4,10 @@ on:
   repository_dispatch:
     types: [graduation_triggered]
 
+permissions:
+  contents: write
+  secrets: read
+
 jobs:
   update-token-info:
     name: Update Token Metadata and Notify


### PR DESCRIPTION
Potential fix for [https://github.com/Boomchainlab/boomchainlab-ci/security/code-scanning/8](https://github.com/Boomchainlab/boomchainlab-ci/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root of the workflow to explicitly define the permissions required. Based on the workflow's actions, the following permissions are necessary:
- `contents: write` for checking out the repository, modifying files, and pushing changes.
- `secrets: read` for accessing the `TWITTER_WEBHOOK` and `RAYDIUM_DISCORD` secrets.

This ensures that the workflow has only the permissions it needs to function correctly, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Boomchainlab/boomchainlab-ci/10)
<!-- Reviewable:end -->
