### PR TITLE
Potential fix for code scanning alert no. 33: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/subgraph-publish.yml
+++ b/.github/workflows/subgraph-publish.yml
@@ -7,6 +7,9 @@ on:
       - 'products-schema.graphql'
       - '.github/workflows/subgraph-publish.yml'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Boomchainlab/boomchainlab-ci/security/code-scanning/33](https://github.com/Boomchainlab/boomchainlab-ci/security/code-scanning/33)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the workflow's operations, it primarily needs `contents: read` to check out the repository and access the schema file. No write permissions are required for the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Boomchainlab/boomchainlab-ci/22)
<!-- Reviewable:end -->
